### PR TITLE
feat: add DNS setup, SSL configuration, and ingress for portfolio

### DIFF
--- a/k8s/DNS_SETUP.md
+++ b/k8s/DNS_SETUP.md
@@ -1,0 +1,111 @@
+# DNS Setup for hugecat.net Domain
+
+This document outlines the DNS configuration required to serve the portfolio application through the hugecat.net domain.
+
+## Overview
+
+The portfolio application has been configured with:
+- Google Cloud Load Balancer with CDN
+- Managed SSL certificates
+- Static IP address
+- Multiple domain routing (hugecat.net, www.hugecat.net, portfolio.hugecat.net)
+
+## Required DNS Configuration
+
+### 1. Get the Static IP Address
+
+After the manifests are deployed, get the static IP address:
+
+```bash
+kubectl get computeglobaladdress portfolio-portfolio-ip -o jsonpath='{.status.address}'
+```
+
+### 2. Configure DNS Records
+
+Add the following DNS records to your hugecat.net domain:
+
+#### A Records
+```
+hugecat.net                A    <STATIC_IP_ADDRESS>
+www.hugecat.net           A    <STATIC_IP_ADDRESS>  
+portfolio.hugecat.net     A    <STATIC_IP_ADDRESS>
+```
+
+#### Alternative: CNAME Records (if using a subdomain)
+```
+www.hugecat.net           CNAME  hugecat.net
+portfolio.hugecat.net     CNAME  hugecat.net
+```
+
+## SSL Certificates
+
+The configuration includes Google-managed SSL certificates for:
+- hugecat.net
+- www.hugecat.net
+- portfolio.hugecat.net
+
+Certificates will be automatically provisioned once:
+1. DNS records are properly configured
+2. Ingress is deployed and healthy
+3. Domain validation completes (usually 10-60 minutes)
+
+## CDN Configuration
+
+The setup includes:
+- **Frontend Config**: HTTPS redirect, SSL policy
+- **Backend Config**: CDN enabled with caching policies
+- **Cache Policy**: 
+  - Static assets cached
+  - API responses not cached
+  - 404/410 errors cached for 5 minutes
+
+## Health Checks
+
+Load balancer health checks are configured to:
+- Check `/api/health` endpoint
+- Use HTTP protocol on port 3000
+- Check every 15 seconds
+- 30-second timeout
+
+## URL Routing
+
+All three domains will serve the same application:
+- `https://hugecat.net` → portfolio application
+- `https://www.hugecat.net` → portfolio application  
+- `https://portfolio.hugecat.net` → portfolio application
+
+HTTP traffic is automatically redirected to HTTPS.
+
+## Verification
+
+After DNS propagation (usually 5-15 minutes), verify setup:
+
+```bash
+# Check certificate status
+kubectl get managedcertificate portfolio-portfolio-ssl-cert
+
+# Check ingress status
+kubectl get ingress portfolio-portfolio-ingress
+
+# Test domains
+curl -I https://hugecat.net
+curl -I https://www.hugecat.net
+curl -I https://portfolio.hugecat.net
+```
+
+## Troubleshooting
+
+### SSL Certificate Issues
+- Verify DNS records point to correct IP
+- Wait up to 60 minutes for certificate provisioning
+- Check certificate status: `kubectl describe managedcertificate`
+
+### DNS Propagation
+- Use `dig` or `nslookup` to verify DNS records
+- Global propagation can take up to 48 hours
+- Use online DNS checker tools
+
+### Load Balancer Issues
+- Check ingress events: `kubectl describe ingress`
+- Verify backend service is healthy
+- Check firewall rules allow HTTP(S) traffic

--- a/k8s/apps/portfolio/base/frontend-config.yaml
+++ b/k8s/apps/portfolio/base/frontend-config.yaml
@@ -1,0 +1,35 @@
+apiVersion: networking.gke.io/v1beta1
+kind: FrontendConfig
+metadata:
+  name: portfolio-frontend-config
+spec:
+  redirectToHttps:
+    enabled: true
+    responseCodeName: MOVED_PERMANENTLY_DEFAULT
+  sslPolicy: portfolio-ssl-policy
+---
+apiVersion: networking.gke.io/v1beta1
+kind: BackendConfig
+metadata:
+  name: portfolio-backend-config
+spec:
+  cdn:
+    enabled: true
+    cachePolicy:
+      includeHost: true
+      includeProtocol: true
+      includeQueryString: false
+    negativeCaching: true
+    negativeCachingPolicy:
+    - code: 404
+      ttl: 300
+    - code: 410
+      ttl: 300
+  healthCheck:
+    checkIntervalSec: 15
+    port: 3000
+    type: HTTP
+    requestPath: /api/health
+  timeoutSec: 30
+  connectionDraining:
+    drainingTimeoutSec: 300

--- a/k8s/apps/portfolio/base/ingress.yaml
+++ b/k8s/apps/portfolio/base/ingress.yaml
@@ -1,0 +1,42 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: portfolio-ingress
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: portfolio-ip
+    networking.gke.io/managed-certificates: portfolio-ssl-cert
+    kubernetes.io/ingress.class: gce
+    kubernetes.io/ingress.allow-http: "false"
+    networking.gke.io/v1beta1.FrontendConfig: portfolio-frontend-config
+spec:
+  rules:
+  - host: portfolio.hugecat.net
+    http:
+      paths:
+      - path: /*
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: portfolio-portfolio
+            port:
+              number: 80
+  - host: hugecat.net
+    http:
+      paths:
+      - path: /*
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: portfolio-portfolio
+            port:
+              number: 80
+  - host: www.hugecat.net
+    http:
+      paths:
+      - path: /*
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: portfolio-portfolio
+            port:
+              number: 80

--- a/k8s/apps/portfolio/base/kustomization.yaml
+++ b/k8s/apps/portfolio/base/kustomization.yaml
@@ -8,6 +8,10 @@ resources:
   - networkpolicy.yaml
   - cloudsql-instance.yaml
   - cloudsql-serviceaccount.yaml
+  - ingress.yaml
+  - ssl-certificate.yaml
+  - frontend-config.yaml
+  - static-ip.yaml
 
 commonLabels:
   app.kubernetes.io/managed-by: flux

--- a/k8s/apps/portfolio/base/service.yaml
+++ b/k8s/apps/portfolio/base/service.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: portfolio
+  annotations:
+    cloud.google.com/backend-config: '{"default": "portfolio-backend-config"}'
 spec:
   selector:
     app: portfolio

--- a/k8s/apps/portfolio/base/ssl-certificate.yaml
+++ b/k8s/apps/portfolio/base/ssl-certificate.yaml
@@ -1,0 +1,9 @@
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: portfolio-ssl-cert
+spec:
+  domains:
+    - hugecat.net
+    - www.hugecat.net
+    - portfolio.hugecat.net

--- a/k8s/apps/portfolio/base/static-ip.yaml
+++ b/k8s/apps/portfolio/base/static-ip.yaml
@@ -1,0 +1,7 @@
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeGlobalAddress
+metadata:
+  name: portfolio-ip
+spec:
+  description: "Static IP for portfolio application"
+  ipVersion: IPV4

--- a/k8s/apps/portfolio/overlays/prod/kustomization.yaml
+++ b/k8s/apps/portfolio/overlays/prod/kustomization.yaml
@@ -98,7 +98,7 @@ configMapGenerator:
     behavior: merge
     literals:
       - NODE_ENV=production
-      - NEXTAUTH_URL=https://portfolio.example.com
+      - NEXTAUTH_URL=https://hugecat.net
       - CLOUD_SQL_CONNECTION_NAME=PROJECT_ID:us-central1:portfolio-prod-db
 
 secretGenerator:

--- a/k8s/flux-system/portfolio-git-repository.yaml
+++ b/k8s/flux-system/portfolio-git-repository.yaml
@@ -1,0 +1,10 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: portfolio-repo
+  namespace: flux-system
+spec:
+  interval: 1m
+  ref:
+    branch: main
+  url: https://github.com/ianlintner/portfolio.git


### PR DESCRIPTION
This pull request introduces Kubernetes manifests and documentation to enable secure, production-grade hosting of the portfolio application on the `hugecat.net` domain. It sets up Google Cloud Load Balancer with CDN, managed SSL certificates, static IP address, and multi-domain routing. The changes ensure HTTPS-only traffic, caching policies, health checks, and provide clear instructions for DNS setup and troubleshooting.

**Infrastructure and Networking Setup**

* Added `Ingress` configuration for multi-domain routing (`hugecat.net`, `www.hugecat.net`, `portfolio.hugecat.net`) with HTTPS-only enforcement and integration with managed certificates and frontend config (`ingress.yaml`).
* Provisioned a static global IP address for the application via `ComputeGlobalAddress` (`static-ip.yaml`).
* Created managed SSL certificate resource for all three domains (`ssl-certificate.yaml`).

**Load Balancer and CDN Configuration**

* Defined `FrontendConfig` and `BackendConfig` resources to enable HTTPS redirection, specify SSL policies, enable CDN with custom caching, and configure health checks for the load balancer (`frontend-config.yaml`).
* Annotated the application `Service` to use the backend config for CDN and health check integration (`service.yaml`).

**Documentation and Deployment**

* Added comprehensive DNS setup documentation for configuring domain records, SSL, CDN, health checks, and troubleshooting (`DNS_SETUP.md`).
* Updated kustomization files to include new resources for ingress, SSL, frontend config, and static IP (`kustomization.yaml`).
* Updated production overlay to use `https://hugecat.net` as the canonical domain (`kustomization.yaml`).
* Added a FluxCD `GitRepository` resource for automated deployment from GitHub (`portfolio-git-repository.yaml`).