### PR TITLE
fix: correct ComputeAddress resource kind from ComputeGlobalAddress

### DIFF
--- a/k8s/apps/portfolio/base/static-ip.yaml
+++ b/k8s/apps/portfolio/base/static-ip.yaml
@@ -1,7 +1,8 @@
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
-kind: ComputeGlobalAddress
+kind: ComputeAddress
 metadata:
   name: portfolio-ip
 spec:
   description: "Static IP for portfolio application"
+  addressType: EXTERNAL
   ipVersion: IPV4


### PR DESCRIPTION
- The CNRM CRD uses ComputeAddress (singular) not ComputeGlobalAddress
- Added addressType: EXTERNAL specification
- This should resolve Flux Kustomization failures