### PR TITLE
style(blog): prettier fix frontmatter title quoting

### DIFF
--- a/src/app/blog/rust-oauth2-server-progress-update-2026.mdx
+++ b/src/app/blog/rust-oauth2-server-progress-update-2026.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Rust OAuth2 Server: Four Months of Progress from v0.0.3 to v0.5.2"
+title: 'Rust OAuth2 Server: Four Months of Progress from v0.0.3 to v0.5.2'
 date: 2026-04-20
 excerpt: >-
   Progress update on the Rust OAuth2/OIDC server since the last deep-dive —


### PR DESCRIPTION
The `Code Quality` job on `main` fails `pnpm format` (`prettier --check .`) because `src/app/blog/rust-oauth2-server-progress-update-2026.mdx` uses double quotes in its YAML frontmatter `title:` but the repo's prettier config prefers single quotes.

Running `prettier --write` on the file produces the one-line diff below, which unblocks the Code Quality check.

Fixes #160.

🤖 Generated with [Claude Code](https://claude.com/claude-code)