### PR TITLE
fix(caretaker): adopt OAuth2 fleet_registry config (v0.20)

### DIFF
--- a/.github/maintainer/config.yml
+++ b/.github/maintainer/config.yml
@@ -121,7 +121,14 @@ escalation:
 fleet_registry:
   enabled: true
   endpoint: https://caretaker.cat-herding.net/api/fleet/heartbeat
-  secret_env: CARETAKER_FLEET_SECRET
+  oauth2:
+    enabled: true
+    client_id_env: OAUTH2_CLIENT_ID
+    client_secret_env: OAUTH2_CLIENT_SECRET
+    token_url_env: OAUTH2_TOKEN_URL
+    scope_env: OAUTH2_SCOPE
+    default_scope: "fleet:heartbeat"
+    timeout_seconds: 10.0
   timeout_seconds: 5.0
   include_full_summary: false
 


### PR DESCRIPTION
Replaces deprecated fleet_registry.secret_env (HMAC) with oauth2: sub-block. Required so v0.19.4's caretaker doctor stops failing on missing CARETAKER_FLEET_SECRET. Backend has been on OAuth2-only auth since v0.20.0.